### PR TITLE
Создать или action или Intent 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Alex Sokolov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ https://www.youtube.com/watch?v=jMAKK0fWFJg
 
 Включаем музыку и узнаём погоду голосом API.AI + Majordomo
 https://www.youtube.com/watch?v=4B4ImDR2st4
+
+Делаем финансового голосового ассистента MajorDomo+API.AI+ExchangeRates
+https://www.youtube.com/watch?v=wZSfGWjE6lc

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ API.AI service integration
 
 Видео по модулю:
 
+Как настроить модуль api.ai в MajorDomo
 https://www.youtube.com/watch?v=jJFTIZ4kLTY
-
+  
+Улучшаем api.ai ассистента в Majordomo 
 https://www.youtube.com/watch?v=jMAKK0fWFJg
+
+Включаем музыку и узнаём погоду голосом API.AI + Majordomo
+https://www.youtube.com/watch?v=4B4ImDR2st4

--- a/modules/apiai/apiai.class.php
+++ b/modules/apiai/apiai.class.php
@@ -239,8 +239,8 @@ function processResponse($data) {
         $this->runAction($action_name,$params);
     }
   
-   //Создать процедуру если нет action т.е. это кастомный интент
-	 if ($data['result']['metadata']['intentName']) {
+   //Иначе если action не задан, то создать процедуру для кастомного интента
+	else if ($data['result']['metadata']['intentName']) {
         $action_name=$data['result']['metadata']['intentName'];
         $params=$data['result']['parameters'];
         $this->runAction($action_name,$params);


### PR DESCRIPTION
Разобрался как задать для интентов свой action. Получается в текущей реализации есди будет задан action, то будет создано 2 процедуры. Одна с именем action, другая в именем intentName. Копии процедур не нужны. Action можно использовать для определения, в каком контексте был получет ответ. Т.е. к примеру когда система задаёт уточняющий вопрос и ответ будет достаточно короткий, то отослав ответ в рамках нужно action будет произведена правильная его обработка. 
![api ai](https://cloud.githubusercontent.com/assets/11455359/23663507/55edcae4-0385-11e7-8c6b-b379c71b2ec1.png)

У нас кста модуль API.AI передаёт action?

ЗЫ: В пул реквест почему автоматически попадают все изменённый файлы, в том числе мой ридми и лицензия. Надеюсь они не помешают?